### PR TITLE
feat: add game history page for players

### DIFF
--- a/drizzle/0003_seed-history-test.sql
+++ b/drizzle/0003_seed-history-test.sql
@@ -1,0 +1,106 @@
+-- Seed data for testing history feature --
+
+-- Add quentin user (password = "password")
+INSERT OR IGNORE INTO users (pseudo, password, admin, ready, canPlayTarot, canPlayTwoTables)
+    VALUES
+    ('quentin', '$2b$10$4ChIYXyx6AjTsDO/F96XoO6wE41Ge3nUqB78obCYPJM0N11a/mNVq', 1, 0, 0, 0);
+
+-- Create finished game tables (Belote = gamemode_id 2)
+INSERT INTO tables (name, finished, panama, gamemode_id)
+    VALUES
+    ('Table 1 (Belote)', 1, 0, 2),
+    ('Table 2 (Belote)', 1, 0, 2),
+    ('Table 3 (Belote)', 1, 0, 2),
+    ('Table 4 (Belote)', 1, 0, 2),
+    ('Table 5 (Belote)', 1, 0, 2);
+
+-- Add players to finished tables
+-- Game 1: quentin + adrien (red) vs florian + paul (black) - quentin wins
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 1 (Belote)' AND u.pseudo = 'quentin';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 1 (Belote)' AND u.pseudo = 'adrien';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 1 (Belote)' AND u.pseudo = 'florian';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 1 (Belote)' AND u.pseudo = 'paul';
+
+-- Game 2: quentin + florian (red) vs gab + seb (black) - quentin loses
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 2 (Belote)' AND u.pseudo = 'quentin';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 2 (Belote)' AND u.pseudo = 'florian';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 2 (Belote)' AND u.pseudo = 'gab';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 2 (Belote)' AND u.pseudo = 'seb';
+
+-- Game 3: quentin + paul (red) vs adrien + gab (black) - quentin wins
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 3 (Belote)' AND u.pseudo = 'quentin';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 3 (Belote)' AND u.pseudo = 'paul';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 3 (Belote)' AND u.pseudo = 'adrien';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 3 (Belote)' AND u.pseudo = 'gab';
+
+-- Game 4: quentin + gab (red) vs florian + seb (black) - quentin wins
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 4 (Belote)' AND u.pseudo = 'quentin';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 4 (Belote)' AND u.pseudo = 'gab';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 4 (Belote)' AND u.pseudo = 'florian';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 4 (Belote)' AND u.pseudo = 'seb';
+
+-- Game 5: quentin + seb (red) vs paul + adrien (black) - quentin loses
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 5 (Belote)' AND u.pseudo = 'quentin';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'red', 0
+    FROM tables t, users u
+    WHERE t.name = 'Table 5 (Belote)' AND u.pseudo = 'seb';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 5 (Belote)' AND u.pseudo = 'paul';
+INSERT INTO tables_users (table_id, user_id, team, winner)
+    SELECT t.id, u.id, 'black', 1
+    FROM tables t, users u
+    WHERE t.name = 'Table 5 (Belote)' AND u.pseudo = 'adrien';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1769042404634,
       "tag": "0002_seed-coinche-users",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1769100000000,
+      "tag": "0003_seed-history-test",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -2,13 +2,15 @@ import journal from './meta/_journal.json';
 import m0000 from './0000_crazy_the_captain.sql';
 import m0001 from './0001_seed-users.sql';
 import m0002 from './0002_seed-coinche-users.sql';
+import m0003 from './0003_seed-history-test.sql';
 
   export default {
     journal,
     migrations: {
       m0000,
 m0001,
-m0002
+m0002,
+m0003
     }
   }
   

--- a/public/history.html
+++ b/public/history.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en" ng-app="meltdownApp">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Historique - Meltdown Belote</title>
+		<link rel="stylesheet" href="/styles.css" />
+		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
+		<script src="history.js"></script>
+	</head>
+	<body ng-controller="HistoryCtrl as ctrl">
+		<div class="form" style="max-width: 900px;">
+			<h2 style="color: var(--gold); margin-top: 0;">Historique de mes parties</h2>
+			<p style="color: var(--text-secondary);" ng-if="ctrl.history.length === 0">Aucune partie terminee pour le moment.</p>
+		</div>
+
+		<div id="tables" ng-if="ctrl.history.length > 0">
+			<div ng-repeat="game in ctrl.history">
+				<div class="table_ready_status">
+					<span ng-class="game.userWon ? 'game-won' : 'game-lost'">
+						{{game.userWon ? 'VICTOIRE' : 'DEFAITE'}}
+					</span>
+					- {{game.tableName}}
+				</div>
+				<table class="tables">
+					<thead>
+						<tr>
+							<th>Joueur</th>
+							<th>Equipe</th>
+							<th>Resultat</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr ng-repeat="player in game.players" ng-class="player.winner ? 'user_ready' : 'user_not_ready'">
+							<td>{{player.pseudo}}</td>
+							<td><span ng-style="{ color: player.team }">{{player.team}}</span></td>
+							<td>{{player.winner ? 'Gagnant' : 'Perdant'}}</td>
+						</tr>
+					</tbody>
+				</table>
+				<hr class="table_separator" />
+			</div>
+		</div>
+
+		<div class="links-container">
+			<a href="/">Index</a>
+			<a href="/stats">Stats</a>
+		</div>
+
+		<style>
+			.game-won {
+				color: #4ade80;
+				font-weight: bold;
+			}
+			.game-lost {
+				color: var(--poker-red-light);
+				font-weight: bold;
+			}
+		</style>
+	</body>
+</html>

--- a/public/history.js
+++ b/public/history.js
@@ -1,0 +1,31 @@
+angular.module('meltdownApp', [])
+    .factory('myHttpInterceptor', function ($q) {
+        return {
+            'request': function(config) {
+                config.headers['Authorization'] = (localStorage.getItem('token') || '').trim();
+                return config;
+            },
+            response: function (response) {
+                return response;
+            },
+            responseError: function (rejection) {
+                if (rejection.status === 401) {
+                    localStorage.removeItem('token');
+                    window.location.href='/login';
+                }
+                console.error('Error response intercepted:', rejection);
+                return $q.reject(rejection);
+            }
+        };
+    })
+    .config(function ($httpProvider) {
+        $httpProvider.interceptors.push('myHttpInterceptor');
+    })
+    .controller('HistoryCtrl', ['$http', function ($http) {
+        const vm = this;
+        vm.history = [];
+
+        $http.get('/user/history').then((response) => {
+            vm.history = response.data;
+        });
+    }]);

--- a/public/index.html
+++ b/public/index.html
@@ -64,6 +64,7 @@
 
 	<div class="links-container">
 		<a href="/stats">Stats</a>
+		<a href="/history">Historique</a>
 		<a href="/account">Mon Compte</a>
 		<a href="/help" target="_blank">Aide</a>
 		<a href="/valeurs.webp" target="_blank">Valeur des cartes</a>

--- a/src/db/schema.types.ts
+++ b/src/db/schema.types.ts
@@ -32,6 +32,21 @@ export type Stat = {
   value: string;
 };
 
+export type GameHistoryPlayer = {
+  pseudo: string;
+  team: string;
+  winner: boolean;
+};
+
+export type GameHistory = {
+  tableId: number;
+  tableName: string;
+  gameMode: string;
+  finishedAt: number | null;
+  players: GameHistoryPlayer[];
+  userWon: boolean;
+};
+
 export type AlarmEvent = { id:string, runAt:number, repeatMs:number };
 
 // ======================================================================

--- a/src/durable.ts
+++ b/src/durable.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from 'cloudflare:workers';
-import { AlarmEvent, FullTable, GameMode, Stat, User } from './db/schema.types';
+import { AlarmEvent, FullTable, GameHistory, GameMode, Stat, User } from './db/schema.types';
 import { drizzle, type DrizzleSqliteDODatabase } from "drizzle-orm/durable-sqlite";
 import { GameService } from './services/GameService';
 import { UserService } from './services/UserService';
@@ -49,7 +49,11 @@ export class MyDurableObject extends DurableObject<Env> {
 	async getStats(user: User) : Promise<Stat[]> {
 		return await this.gameService.getStats(user);
 	}
-	
+
+	async getHistory(user: User, limit: number = 50): Promise<GameHistory[]> {
+		return await this.gameService.getHistory(user, limit);
+	}
+
 	async passwordChange(request: Request, pseudo:string, admin: boolean): Promise<Response> {
 		return this.userService.passwordChange(request, pseudo,admin);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,10 @@ export default {
 			case '/user/stats': {
 				return new Response(JSON.stringify(await stub.getStats(user)));
 			}
+			case '/user/history': {
+				const limit = parseInt(url.searchParams.get('limit') || '50');
+				return new Response(JSON.stringify(await stub.getHistory(user, limit)), success);
+			}
 			case '/tables': {
 				const tables = await stub.getTables();
 				return new Response(JSON.stringify(tables), success);

--- a/src/services/GameService.ts
+++ b/src/services/GameService.ts
@@ -1,4 +1,4 @@
-import { GameMode, Table, User, FullTable, Team, Stat } from '../db/schema.types';
+import { GameMode, Table, User, FullTable, Team, Stat, GameHistory, GameHistoryPlayer } from '../db/schema.types';
 import { DrizzleSqliteDODatabase } from 'drizzle-orm/durable-sqlite';
 import { users, tables, tablesUsers, gameModes } from "../db/schema"; // your schema file
 import { and, eq, sql } from 'drizzle-orm';
@@ -271,9 +271,9 @@ export class GameService {
                         tu2.user_id AS partnerId,
                         COUNT(DISTINCT tu2.table_id) AS gamesTogether,
                         SUM(
-                            CASE 
-                            WHEN tu1.winner = 1 AND tu2.winner = 1 
-                            THEN 1 ELSE 0 
+                            CASE
+                            WHEN tu1.winner = 1 AND tu2.winner = 1
+                            THEN 1 ELSE 0
                             END
                         ) AS winsTogether
                         FROM tables_users tu1
@@ -285,7 +285,7 @@ export class GameService {
                         AND tu2.user_id != tu1.user_id and tables.finished = true and tables.gamemode_id = ${gameMode.id}
                         GROUP BY tu2.user_id
                     )
-                    SELECT 
+                    SELECT
                         p.partnerId,
                         u.pseudo AS partnerPseudo,
                         p.gamesTogether,
@@ -302,7 +302,7 @@ export class GameService {
                     });
                 }
                 const mostPlayedPartner: {partnerPseudo: string, gamesTogether: number}[] = await this.db.all(sql`
-                        SELECT 
+                        SELECT
                         users.pseudo AS partnerPseudo,
                         COUNT(*) AS gamesTogether
                         FROM tables_users tu1
@@ -326,7 +326,7 @@ export class GameService {
                 }
             }
             const gamesPlayed : {games: number}[] = await this.db.all(sql`
-                SELECT 
+                SELECT
                 COUNT(*) AS games
                 FROM tables_users tu1
                 JOIN tables tables
@@ -338,8 +338,64 @@ export class GameService {
             stats.push({
                 value: `${gameMode.name} : Tu a joué ${gamesPlayed[0].games} fois`
             });
-            
-        }    
+
+        }
         return stats;
+    }
+
+    public async getHistory(user: User, limit: number = 50): Promise<GameHistory[]> {
+        const rows: {
+            tableId: number;
+            tableName: string;
+            gameModeName: string;
+            odescriptyPseudo: string;
+            odescriptyTeam: string;
+            odescriptyWinner: number;
+            userWinner: number;
+        }[] = await this.db.all(sql`
+            SELECT
+                t.id as tableId,
+                t.name as tableName,
+                gm.name as gameModeName,
+                u.pseudo as playerPseudo,
+                tu.team as playerTeam,
+                tu.winner as playerWinner,
+                (SELECT tu2.winner FROM tables_users tu2 WHERE tu2.table_id = t.id AND tu2.user_id = ${user.id}) as userWinner
+            FROM tables t
+            JOIN gamesModes gm ON gm.id = t.gamemode_id
+            JOIN tables_users tu ON tu.table_id = t.id
+            JOIN users u ON u.id = tu.user_id
+            WHERE t.finished = true
+            AND t.panama = false
+            AND t.id IN (
+                SELECT table_id FROM tables_users WHERE user_id = ${user.id}
+            )
+            ORDER BY t.id DESC
+            LIMIT ${limit * 10}
+        `);
+
+        const historyMap = new Map<number, GameHistory>();
+
+        for (const row of rows) {
+            if (!historyMap.has(row.tableId)) {
+                historyMap.set(row.tableId, {
+                    tableId: row.tableId,
+                    tableName: row.tableName,
+                    gameMode: row.gameModeName,
+                    finishedAt: null,
+                    players: [],
+                    userWon: row.userWinner === 1
+                });
+            }
+
+            const history = historyMap.get(row.tableId)!;
+            history.players.push({
+                pseudo: (row as any).playerPseudo,
+                team: (row as any).playerTeam,
+                winner: (row as any).playerWinner === 1
+            });
+        }
+
+        return [...historyMap.values()].slice(0, limit);
     }
 }


### PR DESCRIPTION
Players can now view their finished games history at /history. Shows win/loss status, table name, game mode, and all players with their teams.

- Add GameHistory types in schema.types.ts
- Add getHistory() method in GameService
- Add /user/history API endpoint
- Create history.html and history.js frontend
- Add link to history in index.html
- Include seed data for testing